### PR TITLE
icons: [Cpanel, Delphi, Pug, Sourceengine]

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -31,7 +31,7 @@
     "prettier": "prettier --write ."
   },
   "dependencies": {
-    "@devicons-react/beta": "npm:devicons-react@1.5.0-beta.12",
+    "@devicons-react/beta": "npm:devicons-react@1.5.0-beta.13",
     "@devicons-react/latest": "npm:devicons-react@1.4.1",
     "highlight.js": "11.11.1",
     "next": "15.3.3",

--- a/docs/pnpm-lock.yaml
+++ b/docs/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
   .:
     dependencies:
       '@devicons-react/beta':
-        specifier: npm:devicons-react@1.5.0-beta.12
-        version: devicons-react@1.5.0-beta.12(react@19.1.0)
+        specifier: npm:devicons-react@1.5.0-beta.13
+        version: devicons-react@1.5.0-beta.13(react@19.1.0)
       '@devicons-react/latest':
         specifier: npm:devicons-react@1.4.1
         version: devicons-react@1.4.1(react@19.1.0)
@@ -1239,8 +1239,8 @@ packages:
     peerDependencies:
       react: '*'
 
-  devicons-react@1.5.0-beta.12:
-    resolution: {integrity: sha512-UgDYNqqdq6AtSkspJ0LkrJDUR/4r3Um2+VLMZH/P9FSDEyVoF56exmarRIrhYkz40zZBvZcw0MFMZLu1akLzJA==}
+  devicons-react@1.5.0-beta.13:
+    resolution: {integrity: sha512-F7+aVy4X+lZp/5ukfo7eCCvfbPhlEqIptUN38tYVYCUdF3DXt/WFrmzTpEdSaxemzV0tRWah6fNfsxV7XvnocQ==}
     peerDependencies:
       react: '*'
 
@@ -3854,7 +3854,7 @@ snapshots:
     dependencies:
       react: 19.1.0
 
-  devicons-react@1.5.0-beta.12(react@19.1.0):
+  devicons-react@1.5.0-beta.13(react@19.1.0):
     dependencies:
       react: 19.1.0
 

--- a/docs/src/assets/data/icons.beta.json
+++ b/docs/src/assets/data/icons.beta.json
@@ -1525,6 +1525,16 @@
     "tags": ["database"]
   },
   {
+    "name": "Cpanel Original",
+    "componentName": "CpanelOriginal",
+    "tags": ["hosting", "web hosting", "server", "control panel"]
+  },
+  {
+    "name": "Cpanel Original Wordmark",
+    "componentName": "CpanelOriginalWordmark",
+    "tags": ["hosting", "web hosting", "server", "control panel"]
+  },
+  {
     "name": "Cplusplus Line",
     "componentName": "CplusplusLine",
     "tags": ["language"]
@@ -1743,6 +1753,16 @@
     "name": "Debian Plain Wordmark",
     "componentName": "DebianPlainWordmark",
     "tags": ["os", "server"]
+  },
+  {
+    "name": "Delphi Original",
+    "componentName": "DelphiOriginal",
+    "tags": ["language"]
+  },
+  {
+    "name": "Delphi Plain",
+    "componentName": "DelphiPlain",
+    "tags": ["language"]
   },
   {
     "name": "Denojs Original",
@@ -6715,6 +6735,21 @@
     "tags": ["container", "lxc", "virtual machine"]
   },
   {
+    "name": "Pug Line",
+    "componentName": "PugLine",
+    "tags": ["framework", "javascript", "nodejs"]
+  },
+  {
+    "name": "Pug Original",
+    "componentName": "PugOriginal",
+    "tags": ["framework", "javascript", "nodejs"]
+  },
+  {
+    "name": "Pug Plain",
+    "componentName": "PugPlain",
+    "tags": ["framework", "javascript", "nodejs"]
+  },
+  {
     "name": "Pulsar Original",
     "componentName": "PulsarOriginal",
     "tags": ["open-source", "cross-platform", "editor"]
@@ -7874,6 +7909,26 @@
     "name": "Sonarqube Plain Wordmark",
     "componentName": "SonarqubePlainWordmark",
     "tags": ["tool", "security"]
+  },
+  {
+    "name": "Sourceengine Original",
+    "componentName": "SourceengineOriginal",
+    "tags": ["game-engine", "valve", "javascript"]
+  },
+  {
+    "name": "Sourceengine Original Wordmark",
+    "componentName": "SourceengineOriginalWordmark",
+    "tags": ["game-engine", "valve", "javascript"]
+  },
+  {
+    "name": "Sourceengine Plain",
+    "componentName": "SourceenginePlain",
+    "tags": ["game-engine", "valve", "javascript"]
+  },
+  {
+    "name": "Sourceengine Plain Wordmark",
+    "componentName": "SourceenginePlainWordmark",
+    "tags": ["game-engine", "valve", "javascript"]
   },
   {
     "name": "Sourcetree Original",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "devicons-react",
-  "version": "1.5.0-beta.12",
+  "version": "1.5.0-beta.13",
   "description": "Devicons React is a collection of icons that symbolize programming languages, design tools, and development software.",
   "keywords": [
     "programming",


### PR DESCRIPTION
This pull request updates the `devicons-react` package to version `1.5.0-beta.13` and introduces new icons to the `icons.beta.json` data file. The changes include dependency updates, lockfile adjustments, and the addition of several new icon definitions.

### Dependency Updates:
* Updated `@devicons-react/beta` dependency in `docs/package.json` to version `1.5.0-beta.13`.
* Updated the version and resolution integrity of `devicons-react` in `docs/pnpm-lock.yaml` to reflect the new version `1.5.0-beta.13`. [[1]](diffhunk://#diff-a515625c25542655369109674f1312786d3da51433265c528d235dc3340a1bbcL15-R16) [[2]](diffhunk://#diff-a515625c25542655369109674f1312786d3da51433265c528d235dc3340a1bbcL1242-R1243) [[3]](diffhunk://#diff-a515625c25542655369109674f1312786d3da51433265c528d235dc3340a1bbcL3857-R3857)
* Updated the `version` field in the root `package.json` to `1.5.0-beta.13`.

### New Icons Added:
* Added new icons for "Cpanel" (Original and Original Wordmark) in `docs/src/assets/data/icons.beta.json`.
* Added new icons for "Delphi" (Original and Plain) in `docs/src/assets/data/icons.beta.json`.
* Added new icons for "Pug" (Line, Original, and Plain) in `docs/src/assets/data/icons.beta.json`.
* Added new icons for "Sourceengine" (Original, Original Wordmark, Plain, and Plain Wordmark) in `docs/src/assets/data/icons.beta.json`.